### PR TITLE
Shorten English Name, Fix Build Errors

### DIFF
--- a/src/ZhuqueFangsong.glyphspackage/fontinfo.plist
+++ b/src/ZhuqueFangsong.glyphspackage/fontinfo.plist
@@ -2121,7 +2121,7 @@ value = "朱雀仿宋（预览测试版）";
 },
 {
 language = dflt;
-value = "Zhuque Fangsong (technical preview)";
+value = "Zhuque Fangsong (preview)";
 }
 );
 },

--- a/src/ZhuqueFangsong.glyphspackage/fontinfo.plist
+++ b/src/ZhuqueFangsong.glyphspackage/fontinfo.plist
@@ -1939,7 +1939,7 @@ sub omegaperispomeniypogegrammeni.sc by omegaperispomeniypogegrammeni.sc.ss05;
 labels = (
 {
 language = dflt;
-value = "Greek adscript iota\"";
+value = "Greek adscript iota";
 }
 );
 tag = ss05;


### PR DESCRIPTION
This PR is mainly aiming at #48, but I believe it also solved #46.

So for #48 , in commit 3eca82f0f8eea17adfc2c555769534c6208ba4d3 I changed the name from `Zhuque Fangsong (technical preview)` to `Zhuque Fangsong (preview)`.

For #46 , I removed a quotation mark in 49e02569df514555a614971a794c6f0e567805b4 and then I am able to build the font.